### PR TITLE
Improve menu context compat checking

### DIFF
--- a/jump_to_audio_tab.js
+++ b/jump_to_audio_tab.js
@@ -212,13 +212,12 @@ function populateMenu() {
   });
 }
 
-browser.runtime.onInstalled.addListener(() => {
+// As of writing this, only Firefox supports the "tab" context,
+// so we're testing if the context works in our environment,
+// and only adding it to our menu context if so.
+function checkContextCompat()
+{
   let promises = [];
-  // As of writing this (2022/12), only Firefox supports the "tab" context,
-  // so we're testing if the context works in our environment,
-  // and only adding it to our menu context if so.
-  //
-  // TODO: could use the .catch chain syntax here(?)
   const test_contexts = ["tab"];
   for (const context of test_contexts) {
     try {
@@ -265,7 +264,9 @@ browser.runtime.onInstalled.addListener(() => {
         .then(() => populateMenu());
     });
   });
-});
+}
+browser.runtime.onInstalled.addListener(checkContextCompat);
+browser.runtime.onStartup.addListener(checkContextCompat);
 
 function updateAudibleTab(tab) {
   // devtool tabs etc. may have the id 0, at least on Firefox

--- a/jump_to_audio_tab.js
+++ b/jump_to_audio_tab.js
@@ -212,9 +212,9 @@ function populateMenu() {
   });
 }
 
-// As of writing this, only Firefox supports the "tab" context,
-// so we're testing if the context works in our environment,
-// and only adding it to our menu context if so.
+// As of writing this (2022/12), only Firefox supports the "tab" context,
+// so we're testing if the context works in our environment, and only adding
+// it to our menu context if so.
 function checkContextCompat() {
   let promises = [];
   const test_contexts = ["tab"];

--- a/jump_to_audio_tab.js
+++ b/jump_to_audio_tab.js
@@ -215,8 +215,7 @@ function populateMenu() {
 // As of writing this, only Firefox supports the "tab" context,
 // so we're testing if the context works in our environment,
 // and only adding it to our menu context if so.
-function checkContextCompat()
-{
+function checkContextCompat() {
   let promises = [];
   const test_contexts = ["tab"];
   for (const context of test_contexts) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version":2,
     "name":"Jump to Audible Tabs",
-    "version":"0.1.0",
+    "version":"0.1.1",
     "description":"Jump to tabs that are playing audio. Activate with the mouse right-click context menu.",
     "icons":{
         "48":"icons/Volume_Mute.svg",


### PR DESCRIPTION
Check compatibility not only on runtime.onInstalled, but also on runtime.onStartup

This change fixes the Firefox tab context being unavailable