### PR TITLE
Feat/toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Firefox add-on. Quickly jump to a tab that is making noise. Convenient if you ha
 * [Currently unsupported](https://github.com/Rainyan/jump-to-audible-tabs/issues/1), but if you are a developer you may be able to load it manually by following [the dev docs](https://developer.chrome.com/docs/extensions/), and substituting Chromium specific calls with Polyfill.
 
 ## Usage
+### Toolbar icon
+For Firefox, the main toolbar button is available from the *Extensions* button:
+
+![jat_example](https://github.com/Rainyan/jump-to-audible-tabs/assets/6595066/306a4860-dbde-4561-83f7-97e9192da620)
+
+From this list, you can pin it to your browser toolbar if you'd like. Pressing the button will focus on the latest audible tab.
+
+### Context menu
+For more control, the addon also offers a context menu with some additional options.
+
 Right-click on any browser page or a tab (Firefox only), and choose the corresponding action from the "Jump to Audible Tabs" context menu:
 
 ![Example image of the context menu](https://user-images.githubusercontent.com/6595066/234595280-1a239852-5c34-4db2-a8c3-8a4152e7c33f.png)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version":2,
     "name":"Jump to Audible Tabs",
-    "version":"0.1.2",
+    "version":"0.2.0",
     "description":"Jump to tabs that are playing audio. Activate with the mouse right-click context menu.",
     "icons":{
         "48":"icons/Volume_Mute.svg",
@@ -18,5 +18,13 @@
             "jump_to_audio_tab.js"
         ],
         "persistent":true
+    },
+
+    "browser_action": {
+        "default_icon": {
+            "16": "icons/Volume_Mute.svg",
+            "32": "icons/Volume_Mute.svg",
+            "64": "icons/Volume_Mute.svg"
+        }
     }
 }


### PR DESCRIPTION
Fix #5 

For now, this is just a simple implementation of targeting the latest audible tab, without any additional options.

This will allow users to have a big, easily reachable button for accessing the addon's main function.